### PR TITLE
Omit the persist argument to opentap to leave the persistence flag unchanged

### DIFF
--- a/lib/netif.ml
+++ b/lib/netif.ml
@@ -53,7 +53,7 @@ let devices = Hashtbl.create 1
 
 let connect devname =
   try
-    let fd, devname = Tuntap.opentap ~pi:false ~persist:false ~devname () in
+    let fd, devname = Tuntap.opentap ~pi:false ~devname () in
     let dev = Lwt_unix.of_unix_file_descr ~blocking:false fd in
     let mac = Macaddr.make_local (fun _ -> Random.int 256) in
     Tuntap.set_up_and_running devname;


### PR DESCRIPTION
Previously when terminating a unikernel process that was using a persistent tapX device for Tcpip_stack_direct, the device was deleted.

With the next release of tuntap, this change will allow the tap device to persist after terminating a unikernel process.

With the current tuntap v1.0.0, this change won't make any difference because ~persist:false is the default anyway.
