### PR TITLE
Allow cancelling input

### DIFF
--- a/src/netif.ml
+++ b/src/netif.ml
@@ -132,7 +132,7 @@ let rec listen t fn =
       | Error `Disconnected -> t.active <- false ; Error `Disconnected
     in
     process () >>= (function
-        | Ok () -> listen t fn
+        | Ok () -> (listen[@tailcall]) t fn
         | Error e -> Lwt.return (Error e))
   | false -> Lwt.return (Ok ())
 


### PR DESCRIPTION
/cc @samoht - this is a `mirage-net-unix`-side solution to the problem discovered in https://github.com/mirage/mirage/pull/743 , which is exposed because the new DHCP client code calls `listen` to perform the DHCP lease transaction then cancels the first listener before initializing the unikernel.