### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-net-unix.opam
+++ b/mirage-net-unix.opam
@@ -9,7 +9,7 @@ doc: "https://mirage.github.io/mirage-net-unix/"
 bug-reports: "https://github.com/mirage/mirage-net-unix/issues"
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "cstruct" {>= "1.7.1"}
   "cstruct-lwt"
   "lwt" {>= "2.4.3"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.