### PR TITLE
adapt to mirage-net 3.0.0 (instead of mirage-net-lwt) signature:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ script: bash -ex ./.travis-docker.sh
 env:
   global:
   - PACKAGE="mirage-net-unix"
-  - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
   matrix:
-  - DISTRO="alpine" OCAML_VERSION="4.04"
-  - DISTRO="alpine" OCAML_VERSION="4.05"
   - DISTRO="alpine" OCAML_VERSION="4.06"
   - DISTRO="alpine" OCAML_VERSION="4.07"
+  - DISTRO="alpine" OCAML_VERSION="4.08"
+  - DISTRO="alpine" OCAML_VERSION="4.09"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### v2.7.0 (25-Oct-2019)
+
+* Adapt to mirage-net 3.0.0 changes (@hannesm)
+
 ### v2.6.0 (26-Feb-2019)
 
 * Adapt to mirage-net 2.0.0 changs (@hannesm)

--- a/mirage-net-unix.opam
+++ b/mirage-net-unix.opam
@@ -8,12 +8,12 @@ homepage: "https://github.com/mirage/mirage-net-unix"
 doc: "https://mirage.github.io/mirage-net-unix/"
 bug-reports: "https://github.com/mirage/mirage-net-unix/issues"
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.06.0"}
   "dune" {>= "1.0"}
   "cstruct" {>= "1.7.1"}
   "cstruct-lwt"
   "lwt" {>= "2.4.3"}
-  "mirage-net-lwt" {>= "2.0.0"}
+  "mirage-net" {>= "3.0.0"}
   "tuntap" {>= "1.8.0"}
   "alcotest" {with-test}
   "logs"

--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,5 @@
 (library
  (name mirage_net_unix)
  (public_name mirage-net-unix)
- (libraries logs macaddr cstruct cstruct-lwt lwt.unix mirage-net-lwt tuntap)
+ (libraries logs macaddr cstruct cstruct-lwt lwt.unix mirage-net tuntap)
  (wrapped false))

--- a/src/netif.ml
+++ b/src/netif.ml
@@ -16,13 +16,8 @@
  *)
 open Lwt.Infix
 
-[@@@warning "-52"]
-open Mirage_net
-
 let src = Logs.Src.create "netif" ~doc:"Mirage unix network module"
 module Log = (val Logs.src_log src : Logs.LOG)
-
-type +'a io = 'a Lwt.t
 
 type t = {
   id: string;
@@ -71,7 +66,7 @@ let connect devname =
     Log.info (fun m -> m "connect %s with mac %a" devname Macaddr.pp mac);
     Lwt.return t
   with
-  | Failure "tun[open]: Permission denied" ->
+  | Failure "tun[open]: Permission denied" [@warning "-52"] ->
     Lwt.fail_with (err_permission_denied devname)
   | exn -> Lwt.fail exn
 
@@ -81,9 +76,6 @@ let disconnect t =
   Lwt_unix.close t.dev >>= fun () ->
   Tuntap.closetap t.id;
   Lwt.return_unit
-
-type macaddr = Macaddr.t
-type buffer = Cstruct.t
 
 (* Input a frame, and block if nothing is available *)
 let rec read t buf =

--- a/src/netif.mli
+++ b/src/netif.mli
@@ -17,7 +17,7 @@
 
 (** Implementation of the network interface for Unix backends. *)
 
-include Mirage_net_lwt.S
+include Mirage_net.S
 
 val connect : string -> t Lwt.t
 (** [connect tap] connects to the given tap interface. *)


### PR DESCRIPTION
- specialised to Lwt.t and Cstruct.t and Macaddr.t already
- lower OCaml bound is 4.06.0