### PR TITLE
Fix infinite loop when calling Netif.disconnect

### DIFF
--- a/src/netif.ml
+++ b/src/netif.ml
@@ -90,6 +90,9 @@ let rec read t buf =
         | Unix.Unix_error(Unix.ENXIO, _, _) ->
           Log.err (fun m -> m "[read] device %s is down, stopping" t.id);
           Lwt.return (Error `Disconnected)
+        | Unix.Unix_error(Unix.EBADF, _, _) when Lwt_unix.state t.dev = Lwt_unix.Closed ->
+          Log.err (fun m -> m "[read] device %s is not active anymore" t.id);
+          Lwt.return (Error `Canceled)
         | Lwt.Canceled ->
           Log.err (fun m -> m "[read] user program requested cancellation of listen on %s" t.id);
           Lwt.return (Error `Canceled)

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,6 @@
 (executables
  (names test)
- (libraries alcotest mirage-net-unix))
+ (libraries alcotest mirage-net-unix logs.fmt))
 
 (alias
  (name runtest)

--- a/test/test.ml
+++ b/test/test.ml
@@ -39,9 +39,34 @@ let test_write () =
   Netif.write t ~size:(mtu + 14) (fun _data -> mtu + 14) >>= fun _t ->
   Lwt.return_unit
 
+let with_alarm ?(timeout=2) f =
+  (* ensure we don't get stuck in an infinite loop,
+     kill the process with SIGALRM after 2 seconds
+   *)
+  let _: int = Unix.alarm timeout in
+  let t = f ()
+  in
+  Lwt.on_termination t (fun () ->let _:int = Unix.alarm 0 in ());
+  t
+
+
+let test_close_listen () =
+  let open Lwt.Syntax in
+  with_alarm @@ fun () ->
+  Netif.connect "tap3" >>= fun t ->
+  printf "connected\n%!";
+  let listener = Netif.listen t ~header_size:14 (fun _ -> Lwt.return_unit) in
+  Netif.disconnect t >>= fun () ->
+  printf "disconnected\n%!";
+  let+ listener in match listener with
+    | Ok () | Error `Disconnected -> ()
+    | Error e ->
+        Alcotest.failf "Netif.listen failed: %a" Netif.pp_error e
+
 let suite = [
   "connect", `Quick, (fun () -> run test_open) ;
   "disconnect", `Quick, (fun () -> run test_close);
+  "listen+disconnect", `Quick, (fun () -> run test_close_listen);
   "write", `Quick, (fun () -> run test_write);
 ]
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -46,4 +46,6 @@ let suite = [
 ]
 
 let _ =
+  Logs.set_level (Some Logs.Info);
+  Logs.set_reporter (Logs_fmt.reporter ());
   Alcotest.run "mirage-net-unix" [ "tests", suite ]


### PR DESCRIPTION
Running the test requires root, so the CI won't run it, but running manually:
```
$ dune build test/test.exe
$ sudo _build/default/mirage-net-unix/test/test.exe
Testing `mirage-net-unix'.
This run has ID `305VB3VU'.

  [OK]          tests          0   connect.
  [OK]          tests          1   disconnect.
  [OK]          tests          2   listen+disconnect.
  [OK]          tests          3   write.
```